### PR TITLE
3 migrate GitHub workflow from netku repository

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+Dockerfile
+.git
+.vscode
+.gitignore
+makefile
+README.md
+.editorconfig
+.env
+proto
+.github
+k8s
+LICENSE

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: ci
+on:
+  pull_request:
+    branches:
+      - main
+    types: [synchronize, opened]
+
+jobs:
+  install-and-lint:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dev dependencies
+        working-directory: .
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir -r requirements-dev.txt
+      - name: Run Ruff
+        working-directory: .
+        run: |
+          ruff check .
+          ruff format --check .
+
+  docker:
+    name: Build with docker
+    runs-on: ubuntu-latest
+    needs: install-and-lint
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build docker image
+        run: docker build -f  "Dockerfile" .

--- a/.github/workflows/load-pr-data.yml
+++ b/.github/workflows/load-pr-data.yml
@@ -1,0 +1,32 @@
+name: load-pr-data
+
+on:
+  workflow_call:
+    outputs:
+      pr_data:
+        description: "Pull request data"
+        value: ${{ jobs.pr-data.outputs.pr_data }}
+
+jobs:
+  pr-data:
+    name: Load PR data
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    outputs:
+      pr_data: ${{ steps.get_pr_data.outputs.result }}
+
+    steps:
+      - uses: actions/github-script@v7
+        id: get_pr_data
+        with:
+          script: |
+            return (
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: context.sha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              })
+            ).data[0];

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Context of build - project root
+
+# --------------------------------------------
+# Build
+# --------------------------------------------
+FROM python:3.11-slim AS builder
+WORKDIR /build
+
+# Updating pip and installing dependencies for build wheels
+RUN pip install --no-cache-dir --upgrade pip setuptools wheel build
+
+
+# Building service requirements to wheel
+COPY ./services/proxy/requirements.txt .
+RUN pip wheel --no-cache-dir -r requirements.txt -w /build/wheels
+
+
+# --------------------------------------------
+# Run
+# --------------------------------------------
+FROM python:3.11-slim AS final
+WORKDIR /app
+RUN pip install --no-cache-dir --upgrade pip
+
+# Installing wheels from build stage
+COPY --from=builder /build/wheels /tmp/wheels
+RUN pip install --no-cache-dir /tmp/wheels/*.whl
+
+COPY . .
+
+CMD ["python", "--version"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install --no-cache-dir --upgrade pip setuptools wheel build
 
 
 # Building service requirements to wheel
-COPY ./services/proxy/requirements.txt .
+COPY requirements.txt .
 RUN pip wheel --no-cache-dir -r requirements.txt -w /build/wheels
 
 


### PR DESCRIPTION
Resolve #3 

- Added Dockerfile for `ci`.
- Introduced `ci` file with lint and build with docker.

Note:
The `CD` file exists in the [Netku](https://github.com/infanasotku/netku) repository but was not included in the current `PR` because this repo will be deployed using `Kubernetes` instead of `Docker Compose`.
