### PR TITLE
Fixed Docker image references in CI/CD workflows for consistency

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,7 +22,7 @@ jobs:
         name: Check if SHA image exists (from staging)
         shell: bash
         run: |
-          if docker manifest inspect "${{ vars.REGISTRY_URL }}/netku/proxy:${{ github.sha }}" >/dev/null 2>&1; then
+          if docker manifest inspect "${{ vars.REGISTRY_URL }}/netku/netku-proxy:${{ github.sha }}" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "exists=false" >> "$GITHUB_OUTPUT"
@@ -31,9 +31,9 @@ jobs:
       - name: Retag and push :latest from :${{ github.sha }}
         if: steps.check-image.outputs.exists == 'true'
         run: |
-          docker pull "${{ vars.REGISTRY_URL }}/netku/proxy:${{ github.sha }}"
-          docker tag  "${{ vars.REGISTRY_URL }}/netku/proxy:${{ github.sha }}" "${{ vars.REGISTRY_URL }}/netku/proxy:latest"
-          docker push "${{ vars.REGISTRY_URL }}/netku/proxy:latest"
+          docker pull "${{ vars.REGISTRY_URL }}/netku/netku-proxy:${{ github.sha }}"
+          docker tag  "${{ vars.REGISTRY_URL }}/netku/netku-proxy:${{ github.sha }}" "${{ vars.REGISTRY_URL }}/netku/netku-proxy:latest"
+          docker push "${{ vars.REGISTRY_URL }}/netku/netku-proxy:latest"
 
       - name: Build and push :latest (staging image not found)
         if: steps.check-image.outputs.exists == 'false'
@@ -43,7 +43,7 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ${{ vars.REGISTRY_URL }}/netku/proxy:latest
+            ${{ vars.REGISTRY_URL }}/netku/netku-proxy:latest
 
   deploy:
     name: Deploy
@@ -65,6 +65,6 @@ jobs:
 
             sops -d k8s/encoded-secrets.yaml > k8s/temp-secrets.yaml && \
             helm upgrade --install netku-proxy-prod -f k8s/values-prod.yaml \
-            --set events.enabled=false --set container.tag=${{ github.sha }} --namespace netku-prod k8s \
+            --set events.enabled=false --set container.tag=latest --namespace netku-prod k8s \
             && rm k8s/temp-secrets.yaml
           EOF

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -27,7 +27,7 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ${{ vars.REGISTRY_URL }}/netku/proxy:${{ github.sha }}
+            ${{ vars.REGISTRY_URL }}/netku/netku-proxy:${{ github.sha }}
 
   deploy:
     name: Deploy


### PR DESCRIPTION
### Docker image naming updates:
* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L25-R25): Updated the Docker image name from `proxy` to `netku-proxy` in multiple steps, including image inspection, retagging, and pushing ([[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L25-R25), [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L34-R36), [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L46-R46)).
* [`.github/workflows/staging.yml`](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bL30-R30): Updated the Docker image name from `proxy` to `netku-proxy` in the staging workflow ([.github/workflows/staging.ymlL30-R30](diffhunk://#diff-7bb7a67ed05f3845ed1f1b92dc4b87dfb0dd9aba208cca5489055ccef315117bL30-R30)).

### Deployment process changes:
* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L68-R68): Changed the production deployment to use the `latest` image tag instead of the specific commit SHA ([.github/workflows/cd.ymlL68-R68](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L68-R68)).