### PR TITLE
Add RabbitMQ username configuration to values files

### DIFF
--- a/k8s/templates/config.yaml
+++ b/k8s/templates/config.yaml
@@ -14,7 +14,7 @@ data:
   POSTGRES__SQL_SCHEMA: proxy
 
   # RabbitMQ
-  RABBIT__USERNAME: proxy
+  RABBIT__USERNAME: {{ .Values.config.RABBIT__USERNAME }}
   RABBIT__HOST: rabbitmq.infanasotku.com.
   RABBIT__PORT: "5670"
   RABBIT_SCOPE_VHOST: /client

--- a/k8s/values-prod.yaml
+++ b/k8s/values-prod.yaml
@@ -7,6 +7,7 @@ config:
   REDIS__DB: "0"
   REDIS__PORT: "6381"
   RABBIT_PROXY_VHOST: "/proxy"
+  RABBIT__USERNAME: "proxy"
 
 # --- API ---
 api:

--- a/k8s/values-staging.yaml
+++ b/k8s/values-staging.yaml
@@ -7,6 +7,7 @@ config:
   REDIS__DB: "0"
   REDIS__PORT: "6382"
   RABBIT_PROXY_VHOST: "/test/proxy"
+  RABBIT__USERNAME: "test"
 
 # --- API ---
 api:

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -11,6 +11,7 @@ config:
   REDIS__DB: "0"
   REDIS__PORT: "6381"
   RABBIT_PROXY_VHOST: "/proxy"
+  RABBIT__USERNAME: "proxy"
 
 # --- API ---
 api:


### PR DESCRIPTION
### Parameterization of RabbitMQ username:

* [`k8s/templates/config.yaml`](diffhunk://#diff-54ba2e7e1b2256d118a418a59d708262ff5ab70d034a1265604694ee9248fe77L17-R17): Updated the `RABBIT__USERNAME` field to use a Helm template variable (`.Values.config.RABBIT__USERNAME`) for dynamic configuration.

### Environment-specific RabbitMQ username values:

* [`k8s/values-prod.yaml`](diffhunk://#diff-15a8b2c90ba3f07beb363ed8259730ae22727d0fef8b639798c968f4ae322ef4R10): Added the `RABBIT__USERNAME` field with the value `"proxy"` for the production environment.
* [`k8s/values-staging.yaml`](diffhunk://#diff-6ff4d8eca23e6d87273733efbc5db34d49e56c11a8d4901ec56443aae47cb4f4R10): Added the `RABBIT__USERNAME` field with the value `"test"` for the staging environment.
* [`k8s/values.yaml`](diffhunk://#diff-3fe3af995d291438cc7379c90d029aa392c40e51cdb14a7fa715cccc17c99d29R14): Added the `RABBIT__USERNAME` field with the value `"proxy"` as the default value for non-specific environments.