### PR TITLE
7 introduce sentry trace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,6 @@ REDIS__DB=0
 # Paths to cert files using as root for GRPC client
 # Default value in client is `certifi.where()`.
 SSL__ROOT_CERTIFICATES_STRINGS=/path/to/cert1.crt /path/to/cert2.crt
+
+# Sentry
+SENTRY__DSN=https://examplePublicKey@o0.ingest.sentry.io/0

--- a/app/container.py
+++ b/app/container.py
@@ -67,9 +67,13 @@ class Container(containers.DeclarativeContainer):
     engine_uow = providers.Factory(PostgresEngineUnitOfWork, async_sessionmaker)
     outbox_uow = providers.Factory(PostgresOutboxUnitOfWork, async_sessionmaker)
 
-    engine_service = providers.Factory(EngineService, engine_uow, engine_manager)
-    outbox_service = providers.Factory(
-        OutboxService,
+    engine_service = providers.Factory[Awaitable[EngineService]](
+        EngineService,  # type: ignore
+        engine_uow,
+        engine_manager,
+    )
+    outbox_service = providers.Factory[Awaitable[OutboxService]](
+        OutboxService,  # type: ignore
         outbox_uow,
         rabbit_publisher,
     )

--- a/app/controllers/admin/views.py
+++ b/app/controllers/admin/views.py
@@ -60,7 +60,7 @@ class EngineView(ModelView, model=models.Engine):
         uuid = UUID(data["uuid"])
         id = UUID(pk)
 
-        with start_span(op="task", description="Restarting engine") as span:
+        with start_span(op="task", description="Restart engine") as span:
             span.set_tag("engine_id", id.hex)
 
             try:

--- a/app/controllers/admin/views.py
+++ b/app/controllers/admin/views.py
@@ -60,7 +60,7 @@ class EngineView(ModelView, model=models.Engine):
         uuid = UUID(data["uuid"])
         id = UUID(pk)
 
-        with start_span(op="task", description="Restart engine") as span:
+        with start_span(op="task", name="Restart engine") as span:
             span.set_tag("engine_id", id.hex)
 
             try:

--- a/app/controllers/admin/views.py
+++ b/app/controllers/admin/views.py
@@ -1,9 +1,10 @@
 from logging import Logger
 from uuid import UUID
+
 from sqladmin import ModelView
 from sqladmin.filters import StaticValuesFilter, BooleanFilter
 from dependency_injector.wiring import Provide
-
+from sentry_sdk import get_current_scope
 
 from app.services.engine import EngineService
 from app.domains.engine import EngineStatus
@@ -51,6 +52,11 @@ class EngineView(ModelView, model=models.Engine):
         engine_service: EngineService = Provide[Container.engine_service],
         logger: Logger = Provide[Container.logger],
     ):
+        scope = get_current_scope()
+        path_format, _, _ = request.scope["path"].rpartition("/")
+        path_format += "/{engine_id}"
+        scope.set_transaction_name(f"{request.method} {path_format}")
+
         uuid = UUID(data["uuid"])
         id = UUID(pk)
 

--- a/app/controllers/events/engine.py
+++ b/app/controllers/events/engine.py
@@ -77,7 +77,7 @@ async def handle_keyevents(
 
     logger = _get_logger()
 
-    tr_name = f"{key_event.event.upper()} engines/{engine_key} @ {engine_stream.name}"
+    tr_name = f"{key_event.event.upper()} engines/{'{engine_id}'}"
     with start_transaction(op="queue.task", name=tr_name) as tr:
         tr.set_tag("engine_key", engine_key)
         tr.set_tag("outbox_id", outbox_id)

--- a/app/controllers/events/engine.py
+++ b/app/controllers/events/engine.py
@@ -11,6 +11,7 @@ from faststream.broker.message import AckStatus
 from dependency_injector.wiring import inject, Provide
 from redis.asyncio import Redis
 from pydantic import BaseModel
+from sentry_sdk import start_transaction
 
 from app.infra.redis.streams import (
     engine_stream,
@@ -76,34 +77,40 @@ async def handle_keyevents(
 
     logger = _get_logger()
 
-    try:
-        match key_event.event:
-            case "expired":
-                await handle_engine_dead(
-                    engine_key=engine_key,
-                    outbox_id=outbox_id,
-                    version=version,
-                )
-            case "hset":
-                await handle_engine_info_changed(
-                    engine_key=engine_key,
-                    outbox_id=outbox_id,
-                    redis_key=key_event.key,
-                    version=version,
-                )
-            case _:
-                logger.warning(f"Unknown event type: {key_event.event}")
-    except Exception as e:
-        logger.error(
-            f"Error processing event [{key_event.event}] for engine [{engine_key}]  id [{stream_id}]: {e}",
-            exc_info=True,
-        )
-        await message.nack()
-    else:
-        logger.info(
-            f"Processed event [{key_event.event}] for engine [{engine_key}] id [{stream_id}]",
-            extra=dict(channel=engine_stream.name),
-        )
+    tr_name = f"{key_event.event.upper()} engines/{engine_key} @ {engine_stream.name}"
+    with start_transaction(op="queue.task", name=tr_name) as tr:
+        tr.set_tag("engine_key", engine_key)
+        tr.set_tag("outbox_id", outbox_id)
+        tr.set_tag("version", version.to_stream_id())
+
+        try:
+            match key_event.event:
+                case "expired":
+                    await handle_engine_dead(
+                        engine_key=engine_key,
+                        outbox_id=outbox_id,
+                        version=version,
+                    )
+                case "hset":
+                    await handle_engine_info_changed(
+                        engine_key=engine_key,
+                        outbox_id=outbox_id,
+                        redis_key=key_event.key,
+                        version=version,
+                    )
+                case _:
+                    logger.warning(f"Unknown event type: {key_event.event}")
+        except Exception as e:
+            logger.error(
+                f"Error processing event [{key_event.event}] for engine [{engine_key}]  id [{stream_id}]: {e}",
+                exc_info=True,
+            )
+            await message.nack()
+        else:
+            logger.info(
+                f"Processed event [{key_event.event}] for engine [{engine_key}] id [{stream_id}]",
+                extra=dict(channel=engine_stream.name),
+            )
 
 
 @inject

--- a/app/controllers/outbox/relay.py
+++ b/app/controllers/outbox/relay.py
@@ -19,7 +19,7 @@ async def start_outbox_relay(logger: Logger, container: Container = Provide[Cont
                     logger.error(
                         f"Outbox message with ID {r.id} failed to process, attempts: {r.attempts}, reason: {r.error}."
                     )
-            await asyncio.sleep(200 / 1000)
+            await asyncio.sleep(1.5)
 
     async def _wrap():
         try:

--- a/app/controllers/outbox/relay.py
+++ b/app/controllers/outbox/relay.py
@@ -1,21 +1,17 @@
 import asyncio
 from logging import Logger
 from contextlib import asynccontextmanager
-from typing import Awaitable, cast
 
 from dependency_injector.wiring import inject, Provide
 
 from app.container import Container
-from app.services.outbox import OutboxService
 
 
 @asynccontextmanager
 @inject
 async def start_outbox_relay(logger: Logger, container: Container = Provide[Container]):
     async def _loop():
-        outbox_service = await cast(
-            Awaitable[OutboxService], container.outbox_service()
-        )
+        outbox_service = await container.outbox_service()
         while True:
             result = await outbox_service.process_batch()
             for r in result:

--- a/app/controllers/outbox/relay.py
+++ b/app/controllers/outbox/relay.py
@@ -24,7 +24,7 @@ async def start_outbox_relay(logger: Logger, container: Container = Provide[Cont
                 for r in result:
                     if not r.success:
                         logger.error(
-                            f"Outbox message with ID {r.id} failed to process, attempts: {r.attempts}, reason: {r.error}."
+                            f"Outbox message with ID {r.record.id} failed to process, attempts: {r.attempts}, reason: {r.error}."
                         )
             await asyncio.sleep(1.5)
 

--- a/app/controllers/outbox/relay.py
+++ b/app/controllers/outbox/relay.py
@@ -26,7 +26,7 @@ async def start_outbox_relay(logger: Logger, container: Container = Provide[Cont
                         logger.error(
                             f"Outbox message with ID {r.record.id} failed to process, attempts: {r.attempts}, reason: {r.error}."
                         )
-            await asyncio.sleep(1.5)
+            await asyncio.sleep(200 / 1000)
 
     async def _wrap():
         try:

--- a/app/entrypoints/api.py
+++ b/app/entrypoints/api.py
@@ -9,10 +9,14 @@ from app.container import Container
 from app.controllers.admin import create_admin
 
 
-def traces_sampler(ctx):
-    scope = ctx.get("asgi_scope") or {}
-    path = scope.get("path") or ""
-    if path.startswith("/admin") and not path.startswith("/admin/engine/edit"):
+def traces_sampler(ctx: dict):
+    scope: dict = ctx["asgi_scope"]
+    path: str = scope["path"]
+    method: str = scope["method"]
+
+    if path.startswith("/admin") and not (
+        path.startswith("/admin/engine/edit") and method == "POST"
+    ):
         return 0.0
 
     return 1.0

--- a/app/entrypoints/api.py
+++ b/app/entrypoints/api.py
@@ -3,9 +3,19 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from app.infra.config import settings
+from app.infra.sentry import init_sentry
 from app.container import Container
 
 from app.controllers.admin import create_admin
+
+
+def traces_sampler(ctx):
+    scope = ctx.get("asgi_scope") or {}
+    path = scope.get("path") or ""
+    if path.startswith("/admin") and not path.startswith("/admin/engine/edit"):
+        return 0.0
+
+    return 1.0
 
 
 def create_lifespan(container: Container):
@@ -33,6 +43,8 @@ def create_app() -> FastAPI:
             "app.controllers.admin.views",
         ]
     )
+
+    init_sentry(traces_sampler=traces_sampler)
 
     app = FastAPI(redoc_url=None, docs_url=None, lifespan=create_lifespan(container))
     app.__dict__["container"] = container

--- a/app/entrypoints/events.py
+++ b/app/entrypoints/events.py
@@ -6,6 +6,7 @@ from faststream.redis import RedisBroker
 from dependency_injector import providers
 
 from app.infra.config import settings
+from app.infra.sentry import init_sentry
 from app.infra.logging import logger
 from app.container import Container
 
@@ -40,6 +41,8 @@ def create_app():
             "app.controllers.events.engine",
         ]
     )
+
+    init_sentry()
 
     engine_broker = RedisBroker(settings.redis.dsn, logger=logger)
     engine_broker.include_router(engine.router)

--- a/app/infra/config/sentry.py
+++ b/app/infra/config/sentry.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class SentrySettings(BaseModel):
+    dsn: str

--- a/app/infra/config/settings.py
+++ b/app/infra/config/settings.py
@@ -9,6 +9,7 @@ from app.infra.config.postgres import PostgreSQLSettings
 from app.infra.config.rabbitmq import RabbitMQSettings
 from app.infra.config.redis import RedisSettings
 from app.infra.config.ssl import SSLSettings
+from app.infra.config.sentry import SentrySettings
 
 
 class Settings(BaseSettings):
@@ -17,6 +18,7 @@ class Settings(BaseSettings):
     rabbit: RabbitMQSettings
     redis: RedisSettings
     ssl: SSLSettings = Field(default_factory=SSLSettings)
+    sentry: SentrySettings
 
     rabbit_scope_vhost: str = Field()
     rabbit_proxy_vhost: str = Field()

--- a/app/infra/grpc/engine.py
+++ b/app/infra/grpc/engine.py
@@ -65,9 +65,7 @@ class GRPCEngineManager:
         """
         channel = await self._get_channel(addr)
 
-        with start_span(
-            op="grpc.client", description="Restart engine via gRPC"
-        ) as span:
+        with start_span(op="grpc.client", name="Restart engine via gRPC") as span:
             span.set_tag("engine_addr", addr)
 
             stub = XrayStub(channel)

--- a/app/infra/grpc/engine.py
+++ b/app/infra/grpc/engine.py
@@ -2,6 +2,7 @@ from uuid import UUID
 from typing import AsyncContextManager, AsyncIterator
 
 from grpc.aio import Channel
+from sentry_sdk import start_span
 
 from app.infra.grpc.gen.xray_pb2_grpc import XrayStub
 from app.infra.grpc.gen.xray_pb2 import XrayInfo
@@ -64,11 +65,16 @@ class GRPCEngineManager:
         """
         channel = await self._get_channel(addr)
 
-        stub = XrayStub(channel)
-        resp: XrayInfo = await stub.RestartXray(XrayInfo(uuid=str(uuid)))
-        recieved_uuid = UUID(resp.uuid)
-        if recieved_uuid != uuid:
-            raise UUIDMismatchError(uuid, recieved_uuid)
+        with start_span(
+            op="grpc.client", description="Restart engine via gRPC"
+        ) as span:
+            span.set_tag("engine_addr", addr)
+
+            stub = XrayStub(channel)
+            resp: XrayInfo = await stub.RestartXray(XrayInfo(uuid=str(uuid)))
+            recieved_uuid = UUID(resp.uuid)
+            if recieved_uuid != uuid:
+                raise UUIDMismatchError(uuid, recieved_uuid)
 
 
 async def create_grpc_manager(

--- a/app/infra/rabbit/publisher.py
+++ b/app/infra/rabbit/publisher.py
@@ -1,6 +1,10 @@
-from faststream.rabbit import RabbitBroker, RabbitQueue
+import asyncio
 
-from app.schemas.outbox import OutboxDTO
+from faststream.rabbit import RabbitBroker, RabbitQueue
+from sentry_sdk import start_span
+from sentry_sdk.tracing import Span
+
+from app.schemas.outbox import OutboxDTO, OutboxPublishResult
 
 
 class RabbitPublisher:
@@ -8,13 +12,41 @@ class RabbitPublisher:
         self._broker = broker
         self._queue = queue
 
-    async def publish(self, dto: OutboxDTO, *, timeout: int | None = None) -> None:
-        await self._broker.publish(
-            dto.event.to_dict(),
-            queue=self._queue,
-            message_id=dto.id.hex,
-            correlation_id=dto.caused_by,
-            message_type=dto.event.name,
-            content_type="application/json",
-            timeout=timeout,
-        )
+    async def publish_batch(
+        self, dtos: list[OutboxDTO], *, timeout: int | None = None
+    ) -> list[OutboxPublishResult]:
+        with start_span(op="queue.submit", name="Publish outbox batch") as span:
+            span.set_tag("outbox.count", len(dtos))
+
+            return await asyncio.gather(
+                *(self._publish(dto, span=span, timeout=timeout) for dto in dtos)
+            )
+
+    async def _publish(
+        self, dto: OutboxDTO, *, span: Span, timeout: int | None = None
+    ) -> OutboxPublishResult:
+        with span.start_child(op="queue.submit", name="Publish outbox message") as span:
+            span.set_tag("outbox.id", dto.id.hex)
+            span.set_tag("outbox.event", dto.event.name)
+            try:
+                await self._broker.publish(
+                    dto.event.to_dict(),
+                    queue=self._queue,
+                    message_id=dto.id.hex,
+                    correlation_id=dto.caused_by,
+                    message_type=dto.event.name,
+                    content_type="application/json",
+                    timeout=timeout,
+                )
+            except Exception as e:
+                span.set_tag("outbox.error", str(e))
+                return OutboxPublishResult(
+                    record=dto,
+                    success=False,
+                    error=str(e),
+                )
+            return OutboxPublishResult(
+                record=dto,
+                success=True,
+                error=None,
+            )

--- a/app/infra/sentry/__init__.py
+++ b/app/infra/sentry/__init__.py
@@ -1,11 +1,16 @@
 from typing import Any, Callable
 
 import sentry_sdk
+from sentry_sdk.types import Event, Hint
 
 from app.infra.config.settings import settings
 
 
-def init_sentry(*, traces_sampler: Callable[[Any], float] | None = None):
+def init_sentry(
+    *,
+    traces_sampler: Callable[[Any], float] | None = None,
+    before_send_transaction: Callable[[Event, Hint], Any] | None = None,
+):
     traces_sample_rate = None
     if traces_sampler is None:
         traces_sample_rate = 1.0
@@ -15,4 +20,5 @@ def init_sentry(*, traces_sampler: Callable[[Any], float] | None = None):
         traces_sampler=traces_sampler,
         traces_sample_rate=traces_sample_rate,
         send_default_pii=True,
+        before_send_transaction=before_send_transaction,
     )

--- a/app/infra/sentry/__init__.py
+++ b/app/infra/sentry/__init__.py
@@ -1,5 +1,18 @@
+from typing import Any, Callable
+
 import sentry_sdk
 
 from app.infra.config.settings import settings
 
-sentry_sdk.init(dsn=settings.sentry.dsn, traces_sample_rate=1.0, debug=True)
+
+def init_sentry(*, traces_sampler: Callable[[Any], float] | None = None):
+    traces_sample_rate = None
+    if traces_sampler is None:
+        traces_sample_rate = 1.0
+
+    sentry_sdk.init(
+        dsn=settings.sentry.dsn,
+        traces_sampler=traces_sampler,
+        traces_sample_rate=traces_sample_rate,
+        send_default_pii=True,
+    )

--- a/app/infra/sentry/__init__.py
+++ b/app/infra/sentry/__init__.py
@@ -1,0 +1,5 @@
+import sentry_sdk
+
+from app.infra.config.settings import settings
+
+sentry_sdk.init(dsn=settings.sentry.dsn, traces_sample_rate=1.0, debug=True)

--- a/app/schemas/outbox.py
+++ b/app/schemas/outbox.py
@@ -12,7 +12,10 @@ class OutboxDTO(BaseSchema):
 
 
 class OutboxPublishResult(BaseSchema):
-    id: UUID
+    record: OutboxDTO
     success: bool
     error: str | None
+
+
+class OutboxProcessingResult(OutboxPublishResult):
     attempts: int

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -15,7 +15,7 @@ config:
 
 # --- API ---
 api:
-  version: "0.1.2"
+  version: "0.1.3"
   container:
     name: netku-proxy-api
     port: 5100
@@ -37,7 +37,7 @@ api:
 
 # --- EVENTS ---
 events:
-  version: "0.1.1"
+  version: "0.1.2"
   container:
     name: netku-proxy-events
     port: 5101
@@ -54,7 +54,7 @@ events:
 
 # --- OUTBOX ---
 outbox:
-  version: "0.1.0"
+  version: "0.1.1"
   container:
     name: netku-proxy-outbox
     port: 5102

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ faststream[redis]==0.5.44
 asyncpg==0.30.0
 certifi==2025.7.9
 protobuf==6.31.1
+sentry-sdk==2.34.1


### PR DESCRIPTION
### Sentry Integration

* **Initialization**:
  - Added `init_sentry` calls in `app/entrypoints/api.py`, `app/entrypoints/events.py`, and `app/entrypoints/outbox_relay.py` to initialize Sentry with custom sampling and event filtering logic. [[1]](diffhunk://#diff-3c3dc07054569ab3978fdac81d98c5779c1a214666849bd562ceb804a3ff8aceR51-R52) [[2]](diffhunk://#diff-7678bcc5df9113d747dfb8eb13427457e5ed0da029fab9872ac870e5a0424c6fR45-R46) [[3]](diffhunk://#diff-7e6238afbdf3d627e30bf70367f0f6aeb74b2588bb0d3dab3f93f8ef1d028cd0R54-R55)
  - Introduced `traces_sampler` in `api.py` to customize trace sampling based on request paths and methods.
  - Added `before_send_transaction` in `outbox_relay.py` to filter out specific transactions.

* **Configuration**:
  - Added `SentrySettings` to the configuration files (`settings.py` and `sentry.py`) to manage Sentry-specific settings. [[1]](diffhunk://#diff-7e485c90bcd2ccec40160609207e61c9b3e8b6004fbbbe8bacd9ff9414a82c79R1-R5) [[2]](diffhunk://#diff-072704bd457de91b1f3867021c0d914807ad941832f7c3339bd3db306f218ea3R12) [[3]](diffhunk://#diff-072704bd457de91b1f3867021c0d914807ad941832f7c3339bd3db306f218ea3R21)
  - Updated `.env.example` to include a placeholder for the Sentry DSN.

### Transaction and Span Tracking

* **Controllers**:
  - Added Sentry spans in `admin/views.py` to track `update_model` and related operations.
  - Introduced transaction tracking in `events/engine.py` for handling key events.
  - Enhanced outbox relay processing with Sentry transactions in `outbox/relay.py`.

* **Repositories**:
  - Added spans for database operations in `engine.py` and `outbox.py` to monitor queries like `get`, `save`, and `claim_batch`. [[1]](diffhunk://#diff-336045fafdcda3b97b0d4f5b8166d8345ee2f44d520382cb51fac765de8c7ec4L18-R24) [[2]](diffhunk://#diff-0f35299de7e1f1474d687300b919510eef812e160968c1e3a081593dc7b281aeR41-R44) [[3]](diffhunk://#diff-0f35299de7e1f1474d687300b919510eef812e160968c1e3a081593dc7b281aeL70-R75) [[4]](diffhunk://#diff-336045fafdcda3b97b0d4f5b8166d8345ee2f44d520382cb51fac765de8c7ec4R98-R100)

* **Unit of Work**:
  - Wrapped unit of work lifecycle methods with spans to track operations like starting and flushing outbox events in `uow.py`. [[1]](diffhunk://#diff-e0e00475ad2ef9cd0302db550b43d5e210b78e2a69f929202295b2b34108d31aR94-R106) [[2]](diffhunk://#diff-e0e00475ad2ef9cd0302db550b43d5e210b78e2a69f929202295b2b34108d31aR141)

* **gRPC**:
  - Added spans for gRPC client operations in `engine.py` to monitor calls like `restart`.