### PR TITLE
Enhance RabbitBroker initialization with client properties for heartbeat

### DIFF
--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -85,3 +85,10 @@ jobs:
             --set container.tag=latest --namespace netku-prod k8s \
             && rm k8s/temp-secrets.yaml
           EOF
+
+      - name: Uninstall staging
+        run: |
+          ssh -p ${{ secrets.SSH_PORT }} root@${{ secrets.SERVER_IP }} << 'EOF'
+            cd ${{ secrets.PROJECT_DIR }}
+            helm uninstall netku-proxy-staging --namespace netku-staging
+          EOF

--- a/app/container.py
+++ b/app/container.py
@@ -2,7 +2,7 @@ from typing import Awaitable
 
 from dependency_injector import providers, containers
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
-from faststream.rabbit import RabbitBroker, RabbitQueue
+from faststream.rabbit import RabbitBroker, RabbitQueue, utils
 from faststream.redis import RedisBroker
 
 from app.services.engine import EngineService
@@ -18,7 +18,12 @@ from app.infra.rabbit import queues
 async def get_broker(dsn: str, *, virtualhost: str | None = None):
     if virtualhost is not None and virtualhost.startswith("/"):
         virtualhost = "/" + virtualhost
-    broker = RabbitBroker(dsn, virtualhost=virtualhost, publisher_confirms=True)
+    broker = RabbitBroker(
+        dsn,
+        virtualhost=virtualhost,
+        publisher_confirms=True,
+        client_properties=utils.RabbitClientProperties(heartbeat=20),
+    )
     await broker.connect()
     try:
         yield broker

--- a/app/container.py
+++ b/app/container.py
@@ -22,6 +22,9 @@ async def get_broker(dsn: str, *, virtualhost: str | None = None):
         dsn,
         virtualhost=virtualhost,
         publisher_confirms=True,
+        # Heartbeat interval set to 20 seconds to balance timely detection of dead connections
+        # and avoid excessive network traffic. This value helps maintain connection reliability
+        # without causing unnecessary disconnects due to transient network issues.
         client_properties=utils.RabbitClientProperties(heartbeat=20),
     )
     await broker.connect()


### PR DESCRIPTION
This pull request updates the RabbitMQ broker configuration in the application's dependency injection container. The main change is the addition of custom client properties to the broker setup, specifically setting a heartbeat interval to improve connection reliability.

RabbitMQ broker configuration:

* The `RabbitBroker` is now initialized with custom client properties using `utils.RabbitClientProperties`, setting the heartbeat interval to 20 seconds to help maintain stable connections.