### PR TITLE
52 uninstall test deployments silently

### DIFF
--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           ssh -p ${{ secrets.SSH_PORT }} root@${{ secrets.SERVER_IP }} << 'EOF'
             cd ${{ secrets.PROJECT_DIR }}
-            helm uninstall netku-proxy-staging --namespace netku-staging
+            helm uninstall --ignore-not-found netku-proxy-staging --namespace netku-staging
           EOF
 
       - name: Redeploy dev via SSH


### PR DESCRIPTION
This pull request makes a minor improvement to the deployment workflow by updating the Helm uninstall command to be more robust.

* Deployment workflow improvement:
  * [`.github/workflows/promote-prod.yml`](diffhunk://#diff-47755401e36a582bf81bd1ecd4d78ec21f324c53fca8fb96b5d5ecd62518698bL93-R93): Added the `--ignore-not-found` flag to the `helm uninstall` command to prevent errors if the release does not exist during the staging cleanup step.