### PR TITLE
56 remove broker pinging from livenessprobe 

### DIFF
--- a/k8s/templates/events-deployment.yaml
+++ b/k8s/templates/events-deployment.yaml
@@ -71,7 +71,7 @@ spec:
           {{- if ne .Values.environment "dev" }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: {{.Values.events.container.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -79,7 +79,7 @@ spec:
 
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: {{.Values.events.container.port }}
             initialDelaySeconds: 10
             periodSeconds: 10


### PR DESCRIPTION
The `/healthz` endpoint has been split into `/livez` and `/readyz` as follows:
- The `/livez` endpoint doesn’t ping `Redis` and just returns `204` with no body.
- The `/readyz` pings `Redis` and then returns `204` with no body.